### PR TITLE
Fix license copyright attribution.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 The Python Packaging Authority
+Copyright (c) Dr. Grant Paton-Simpson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
* Attribute to author (Dr. Grant Paton-Simpson)
* Remove year of copyright
* Include trailing newline character.